### PR TITLE
Add title and message to Hokusai action sheet

### DIFF
--- a/Classes/Hokusai.swift
+++ b/Classes/Hokusai.swift
@@ -128,8 +128,12 @@ final public class HOKButton: UIButton {
 }
 
 final public class HOKLabel: UILabel {
+    var isTitle = true
+    
     // Font
-    let kDefaultFont      = "AvenirNext-DemiBold"
+    var kDefaultFont:String {
+        return isTitle ? "AvenirNext-DemiBold" : "AvenirNext-Light"
+    }
     let kFontSize:CGFloat = 16.0
     
     func setColor(colors: HOKColors) {
@@ -245,10 +249,13 @@ final public class Hokusai: UIViewController, UIGestureRecognizerDelegate {
     // Variables users can change
     public var colorScheme        = HOKColorScheme.Hokusai
     public var fontName           = ""
+    public var lightFontName      = ""
     public var colors:HOKColors!  = nil
     public var cancelButtonTitle  = "Cancel"
     public var cancelButtonAction : (()->Void)?
     public var headline: String   = ""
+    public var message:String     = ""
+
     
     required public init(coder aDecoder: NSCoder) {
         fatalError("NSCoding not supported")
@@ -274,10 +281,11 @@ final public class Hokusai: UIViewController, UIGestureRecognizerDelegate {
         NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(Hokusai.onOrientationChange(_:)), name: UIDeviceOrientationDidChangeNotification, object: nil)
     }
     
-    /// Convenience initializer to allow a single lined title
-    convenience public init(headline: String) {
+    /// Convenience initializer to allow a title and optional message
+    convenience public init(headline: String, message: String = "") {
         self.init()
         self.headline = headline
+        self.message  = message
     }
     
     func onOrientationChange(notification: NSNotification) {
@@ -371,13 +379,20 @@ final public class Hokusai: UIViewController, UIGestureRecognizerDelegate {
         return btn
     }
     
-    // Add a label with a text
+    // Add a multi-lined message label
+    private func addMessageLabel(text: String) -> HOKLabel {
+        let label = addLabel(text)
+        label.isTitle = false
+        return label
+    }
+    
+    // Add a multi-lined label just with a text
     private func addLabel(text: String) -> HOKLabel {
         let label = HOKLabel()
         label.layer.masksToBounds = true
         label.textAlignment = .Center
         label.text = text
-        label.numberOfLines = 1
+        label.numberOfLines = 0
         menuView.addSubview(label)
         labels.append(label)
         return label
@@ -411,6 +426,11 @@ final public class Hokusai: UIViewController, UIGestureRecognizerDelegate {
             self.addLabel(headline)
         }
         
+        // Add a message label when message is set
+        if !message.isEmpty {
+            self.addMessageLabel(message)
+        }
+
         // Style buttons
         for btn in buttons {
             btn.layer.cornerRadius = kButtonHeight * 0.5
@@ -420,7 +440,7 @@ final public class Hokusai: UIViewController, UIGestureRecognizerDelegate {
         
         // Style labels
         for label in labels {
-            label.setFontName(fontName)
+            label.setFontName( label.isTitle ? fontName : lightFontName)
             label.setColor(colors)
         }
         

--- a/Classes/Hokusai.swift
+++ b/Classes/Hokusai.swift
@@ -127,6 +127,27 @@ final public class HOKButton: UIButton {
     }
 }
 
+final public class HOKLabel: UILabel {
+    // Font
+    let kDefaultFont      = "AvenirNext-DemiBold"
+    let kFontSize:CGFloat = 16.0
+    
+    func setColor(colors: HOKColors) {
+        self.textColor = colors.fontColor
+        self.backgroundColor = UIColor.clearColor()
+    }
+    
+    func setFontName(fontName: String?) {
+        let name:String
+        if let fontName = fontName where !fontName.isEmpty {
+            name = fontName
+        } else {
+            name = kDefaultFont
+        }
+        self.font = UIFont(name: name, size:kFontSize)
+    }
+}
+
 final public class HOKMenuView: UIView {
     var colorScheme = HOKColorScheme.Hokusai
     
@@ -209,14 +230,17 @@ final public class HOKMenuView: UIView {
 
 final public class Hokusai: UIViewController, UIGestureRecognizerDelegate {
     // Views
-    private var menuView = HOKMenuView()
-    private var buttons  = [HOKButton]()
+    private var menuView   = HOKMenuView()
+    private var buttons    = [HOKButton]()
+    private var labels     = [HOKLabel]()
     
-    private var instance:Hokusai!       = nil
-    private var kButtonWidth:CGFloat    = 250
-    private let kButtonHeight:CGFloat   = 48.0
-    private let kButtonInterval:CGFloat = 16.0
-    private var bgColor                 = UIColor(white: 1.0, alpha: 0.7)
+    private var instance:Hokusai!        = nil
+    private var kButtonWidth:CGFloat     = 250
+    private let kButtonHeight:CGFloat    = 48.0
+    private let kElementInterval:CGFloat = 16.0
+    private var kLabelWidth:CGFloat { return kButtonWidth }
+    private let kLabelHeight:CGFloat     = 30.0
+    private var bgColor                  = UIColor(white: 1.0, alpha: 0.7)
     
     // Variables users can change
     public var colorScheme        = HOKColorScheme.Hokusai
@@ -224,6 +248,7 @@ final public class Hokusai: UIViewController, UIGestureRecognizerDelegate {
     public var colors:HOKColors!  = nil
     public var cancelButtonTitle  = "Cancel"
     public var cancelButtonAction : (()->Void)?
+    public var headline: String   = ""
     
     required public init(coder aDecoder: NSCoder) {
         fatalError("NSCoding not supported")
@@ -249,11 +274,37 @@ final public class Hokusai: UIViewController, UIGestureRecognizerDelegate {
         NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(Hokusai.onOrientationChange(_:)), name: UIDeviceOrientationDidChangeNotification, object: nil)
     }
     
+    /// Convenience initializer to allow a single lined title
+    convenience public init(headline: String) {
+        self.init()
+        self.headline = headline
+    }
+    
     func onOrientationChange(notification: NSNotification) {
-        
+        self.updateFrames()
+        self.view.layoutIfNeeded()
+    }
+    
+    func updateFrames() {
         kButtonWidth = view.frame.width * 0.8
         
-        let menuHeight = CGFloat(buttons.count + 2) * kButtonInterval + CGFloat(buttons.count) * kButtonHeight
+        var yPrevious:CGFloat = 0
+        for label in labels {
+            label.frame  = CGRect(x: 0.0, y: 0.0, width: kLabelWidth, height: kLabelHeight)
+            label.sizeToFit()
+            label.center = CGPoint(x: view.center.x, y: label.frame.size.height * 0.5 + yPrevious + kElementInterval)
+            yPrevious = CGRectGetMaxY(label.frame)
+        }
+        
+        for btn in buttons {
+            btn.frame  = CGRect(x: 0.0, y: 0.0, width: kButtonWidth, height: kButtonHeight)
+            btn.center = CGPoint(x: view.center.x, y: kButtonHeight * 0.5 + yPrevious + kElementInterval)
+            yPrevious = CGRectGetMaxY(btn.frame)
+        }
+        
+        let labelHeights = labels.flatMap { CGRectGetHeight($0.frame) }.reduce(0, combine: +)
+        let buttonHeights = buttons.flatMap { CGRectGetHeight($0.frame) }.reduce(0, combine: +)
+        let menuHeight = CGFloat(buttons.count + labels.count + 1) * kElementInterval + labelHeights + buttonHeights
         menuView.frame = CGRect(
             x: 0,
             y: view.frame.height - menuHeight,
@@ -263,13 +314,7 @@ final public class Hokusai: UIViewController, UIGestureRecognizerDelegate {
         
         menuView.shapeLayer.frame = CGRect(origin: CGPointZero, size: menuView.frame.size)
         menuView.updatePath()
-        
-        for i in 0 ..< buttons.count {
-            let btn = buttons[i]
-            btn.frame  = CGRect(x: 0.0, y: 0.0, width: kButtonWidth, height: kButtonHeight)
-            btn.center = CGPoint(x: view.center.x, y: -kButtonHeight * 0.25 + (kButtonHeight + kButtonInterval) * CGFloat(i + 1))
-        }
-        self.view.layoutIfNeeded()
+        menuView.layoutIfNeeded()
     }
     
     override public init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?) {
@@ -326,6 +371,18 @@ final public class Hokusai: UIViewController, UIGestureRecognizerDelegate {
         return btn
     }
     
+    // Add a label with a text
+    private func addLabel(text: String) -> HOKLabel {
+        let label = HOKLabel()
+        label.layer.masksToBounds = true
+        label.textAlignment = .Center
+        label.text = text
+        label.numberOfLines = 1
+        menuView.addSubview(label)
+        labels.append(label)
+        return label
+    }
+    
     // Show the menu
     public func show() {
         if let rv = UIApplication.sharedApplication().keyWindow {
@@ -349,24 +406,26 @@ final public class Hokusai: UIViewController, UIGestureRecognizerDelegate {
         // Add a cancel button
         self.addCancelButton(cancelButtonTitle)
         
-        // Decide the menu size
-        let menuHeight = CGFloat(buttons.count + 2) * kButtonInterval + CGFloat(buttons.count) * kButtonHeight
-        menuView.frame = CGRect(
-            x: 0,
-            y: view.frame.height - menuHeight,
-            width: view.frame.width,
-            height: menuHeight
-        )
+        // Add a title label when title is set
+        if !headline.isEmpty {
+            self.addLabel(headline)
+        }
         
-        // Locate buttons
-        for i in 0 ..< buttons.count {
-            let btn = buttons[i]
-            btn.frame  = CGRect(x: 0.0, y: 0.0, width: kButtonWidth, height: kButtonHeight)
-            btn.center = CGPoint(x: view.center.x, y: -kButtonHeight * 0.25 + (kButtonHeight + kButtonInterval) * CGFloat(i + 1))
+        // Style buttons
+        for btn in buttons {
             btn.layer.cornerRadius = kButtonHeight * 0.5
             btn.setFontName(fontName)
             btn.setColor(colors)
         }
+        
+        // Style labels
+        for label in labels {
+            label.setFontName(fontName)
+            label.setColor(colors)
+        }
+        
+        // Set frames
+        self.updateFrames()
         
         // Animations
         animationWillStart()
@@ -401,7 +460,6 @@ final public class Hokusai: UIViewController, UIGestureRecognizerDelegate {
             options: [.BeginFromCurrentState, .AllowUserInteraction, .OverrideInheritedOptions],
             animations: {
                 self.menuView.frame = CGRect(origin: CGPoint(x: 0.0, y: self.view.frame.height-self.menuView.frame.height), size: self.menuView.frame.size)
-                self.menuView.layoutIfNeeded()
             },
             completion: {(finished) in
         })

--- a/Example/Hokusai/ViewController.swift
+++ b/Example/Hokusai/ViewController.swift
@@ -60,16 +60,6 @@ class ViewController: UIViewController, UICollectionViewDataSource, UICollection
         // Here is the implementation for Hokusai. //
         /////////////////////////////////////////////
         
-        // Init with title
-        let hokusai2 = Hokusai(headline: "Information")
-        
-        // Init with title and message
-        let hokusai3 = Hokusai(headline: "Information", message: "This can be a long multi-lined message.")
-        
-        // ...or add title and message later
-        hokusai2.headline = "Infomration"
-        hokusai2.message  = "This can be a long multi-lined message."
-        
         let hokusai = Hokusai()
         if indexPath.row % 2 == 0 {
             

--- a/Example/Hokusai/ViewController.swift
+++ b/Example/Hokusai/ViewController.swift
@@ -59,8 +59,26 @@ class ViewController: UIViewController, UICollectionViewDataSource, UICollection
         /////////////////////////////////////////////
         // Here is the implementation for Hokusai. //
         /////////////////////////////////////////////
-
+        
+        // Init with title
+        let hokusai2 = Hokusai(headline: "Information")
+        
+        // Init with title and message
+        let hokusai3 = Hokusai(headline: "Information", message: "This can be a long multi-lined message.")
+        
+        // ...or add title and message later
+        hokusai2.headline = "Infomration"
+        hokusai2.message  = "This can be a long multi-lined message."
+        
         let hokusai = Hokusai()
+        if indexPath.row % 2 == 0 {
+            
+            // Add a title
+            hokusai.headline = "Information"
+            
+            // Add a message
+            hokusai.message  = "Katsushika Hokusai (葛飾 北斎) was a Japanese artist, ukiyo-e painter and printmaker of the Edo period."
+        }
         
         // Add a button with a closure
         hokusai.addButton("Button 1") {
@@ -71,7 +89,10 @@ class ViewController: UIViewController, UICollectionViewDataSource, UICollection
         hokusai.addButton("Button 2", target: self, selector: #selector(ViewController.button2Pressed))
         
         // Set a font name. Default is AvenirNext-DemiBold.
-        hokusai.fontName = "Verdana-Bold"
+        hokusai.fontName      = "Verdana-Bold"
+        
+        // Set a light font name used for the message. Default is AvenirNext-Light
+        hokusai.lightFontName = "Verdana"
 
         // Change a title for cancel button (Default is Cancel)
         hokusai.cancelButtonTitle = "Done"

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
-  - Hokusai (0.1.23)
+  - Hokusai (0.2.1)
 
 DEPENDENCIES:
   - Hokusai (from `../`)
 
 EXTERNAL SOURCES:
   Hokusai:
-    :path: "../"
+    :path: ../
 
 SPEC CHECKSUMS:
-  Hokusai: ae652f73a7c4811cfccad0c0ad80ac469fb934fc
+  Hokusai: 65da2cc529926068119fd9ff77f7bab6e20acb20
 
 COCOAPODS: 0.39.0

--- a/README.md
+++ b/README.md
@@ -72,6 +72,19 @@ hokusai.cancelButtonAction = {
 
 ```
 
+#### Add a title and message
+```
+// Init with title
+let hokusai = Hokusai(headline: "Information")
+
+// Init with title and message
+let hokusai = Hokusai(headline: "Information", message: "This can be a long multi-lined message.")
+
+// ...or add title and message later, but before you call `show()`
+hokusai.headline = "Infomration"
+hokusai.message  = "This can be a long multi-lined message."
+```
+
 #### Add a button with a closure
 ```
 hokusai.addButton("Button Title") {


### PR DESCRIPTION
As promised I took some time to add my changes in a more general usable manner.

You can initialize Hokusai with a `headline` and/or a `message` which will than be displayed in the action sheet. Both properties are public, so they can also be set and changed afterwards.
To display the message I also introduced a `lightFontName` property which when set is used for the message.

Unfortunately I did not find a easy way to use `title` as the property name, because it is already used by `UIViewController`. Maybe somebody else sees a neat way?

Relates to: #10 
